### PR TITLE
Fix a typo which prevents the build against non-ZTS php distribution

### DIFF
--- a/fiftyonedegrees.c
+++ b/fiftyonedegrees.c
@@ -227,7 +227,7 @@ PHP_MINIT_FUNCTION(fiftyonedegrees) {
             (ts_allocate_dtor) NULL);
     //            (ts_allocate_dtor) fiftyonedegrees_destroy_globals);
 #else
-    fiftyonedegrees_init_globals(&fiftyonedegrees_global TSRMLS_CC);
+    fiftyonedegrees_init_globals(&fiftyonedegrees_globals TSRMLS_CC);
 #endif
 
     zend_class_entry ce;


### PR DESCRIPTION
This fixes issue https://github.com/whatvn/php7-51degrees/issues/1

